### PR TITLE
Update extract method per specification

### DIFF
--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -26,9 +26,8 @@ module OpenTracing
     # Extract a span from a carrier
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
     # @param carrier [Carrier]
-    # @param tracer [Tracer] the tracer the span will be attached to (for finish)
     # @return [SpanContext]
-    def extract(format, carrier, tracer = nil)
+    def extract(format, carrier)
       case format
       when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK
         return SpanContext::NOOP_INSTANCE

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -24,12 +24,11 @@ module OpenTracing
     end
 
     # Extract a span from a carrier
-    # @param operation_name [String]
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
     # @param carrier [Carrier]
     # @param tracer [Tracer] the tracer the span will be attached to (for finish)
-    # @return [Span]
-    def extract(operation_name, format, carrier)
+    # @return [SpanContext]
+    def extract(format, carrier, tracer = nil)
       case format
       when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK
         return SpanContext::NOOP_INSTANCE


### PR DESCRIPTION
- Remove operation_name
- Return value is a SpanContext
- Removed Tracer from method docs since this method belongs to a tracer already

Per the extract documentation in the [specification](https://github.com/opentracing/specification/blob/master/specification.md#extract-a-spancontext-from-a-carrier)