### PR TITLE
Span.initialize: Use old-style params for Ruby 2.0

### DIFF
--- a/lib/opentracing/span.rb
+++ b/lib/opentracing/span.rb
@@ -19,7 +19,7 @@ module OpenTracing
     # @param tracer [Tracer] the tracer that created this span
     # @param context [SpanContext] the context of the span
     # @return [Span] a new Span
-    def initialize(tracer:, context:)
+    def initialize(tracer, span_context)
     end
 
     # Set a tag value on this span

--- a/lib/opentracing/span.rb
+++ b/lib/opentracing/span.rb
@@ -17,7 +17,7 @@ module OpenTracing
     # Creates a new {Span}
     #
     # @param tracer [Tracer] the tracer that created this span
-    # @param context [SpanContext] the context of the span
+    # @param span_context [SpanContext] the context of the span
     # @return [Span] a new Span
     def initialize(tracer, span_context)
     end


### PR DESCRIPTION
Previously used required named arguments (without defaults)
which was added in Ruby 2.1