### PR TITLE
Bring OpenTracing lib into compliance with OT spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ client = Net::HTTP.new("http://myservice")
 req = Net::HTTP::Post.new("/")
 
 span = OpenTracing.start_span("my_span")
-OpenTracing.inject(span.context, OpenTracing::FORMAT_HTTP_HEADER, req)
+OpenTracing.inject(span.context, OpenTracing::FORMAT_RACK, env)
 res = client.request(req)
 #...
 ```
@@ -96,7 +96,8 @@ it will not be possible to discern once Rack has processed it.
 ```ruby
 class MyRackApp
   def call(env)
-    span = @tracer.extract("my_app", OpenTracing::FORMAT_RACK, env, OpenTracing.global_tracer)
+    extracted_ctx = @tracer.extract("my_app", OpenTracing::FORMAT_RACK, env)
+    span = @tracer.start_span("my_app", child_of: extracted_ctx)
     span.finish
     [200, {}, ["hello"]]
   end

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ it will not be possible to discern once Rack has processed it.
 ```ruby
 class MyRackApp
   def call(env)
-    extracted_ctx = @tracer.extract("my_app", OpenTracing::FORMAT_RACK, env)
+    extracted_ctx = @tracer.extract(OpenTracing::FORMAT_RACK, env)
     span = @tracer.start_span("my_app", child_of: extracted_ctx)
     span.finish
     [200, {}, ["hello"]]

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -5,14 +5,27 @@ require "opentracing/span"
 require "opentracing/tracer"
 
 module OpenTracing
-  # Text format for #inject and #extract
+  # Text format for Tracer#inject and Tracer#extract.
+  #
+  # The carrier for FORMAT_TEXT_MAP should be a Hash with string values.
   FORMAT_TEXT_MAP = 1
 
   # Binary format for #inject and #extract
+  #
+  # The carrier for FORMAT_BINARY should be a string, treated as a raw sequence
+  # of bytes.
   FORMAT_BINARY = 2
 
-  # Ruby Specific format to handle how Rack changes environment variables.
-  # See Readme.md for more info.
+  # Due to Rack's popularity within the Ruby community, OpenTracing-Ruby
+  # provides a Rack-specific format for injection into and extraction from HTTP
+  # headers specifically, though there are some strings attached.
+  #
+  # The carrier for FORMAT_RACK should be `env` or equivalent. It behaves like
+  # FORMAT_TEXT_MAP, but with all keys transformed per Rack's treatment of HTTP
+  # headers. Keep in mind that Rack automatically uppercases all headers and
+  # replaces dashes with underscores. This means that if you use dashes and
+  # underscores and case-sensitive baggage keys, they may collide or become
+  # unrecognizable.
   FORMAT_RACK = 3
 
   class << self

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -1,19 +1,25 @@
 module OpenTracing
   class Tracer
-    # Start a new span
-    # @param operation_name [String] The name of the operation represented by the span
-    # @param child_of [Span] A span to be used as the ChildOf reference
-    # @param start_time [Time] the start time of the span
-    # @param tags [Hash] Starting tags for the span
+    # TODO(bhs): Support FollowsFrom and multiple references
+
+    # Starts a new span.
+    #
+    # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        .span_context is automatically substituted.
+    # @param start_time [Time] When the Span started, if not now
+    # @param tags [Hash] Tags to assign to the Span at start time
+    # @return [Span] The newly-started Span
     def start_span(operation_name, child_of: nil, start_time: nil, tags: nil)
       Span::NOOP_INSTANCE
     end
 
-
-    # Inject a span into the given carrier
-    # @param span_context [SpanContext]
+    # Inject a SpanContext into the given carrier
+    #
+    # @param spancontext [SpanContext]
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
-    # @param carrier [Carrier]
+    # @param carrier [Hash]
     def inject(span_context, format, carrier)
       case format
       when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK
@@ -23,13 +29,12 @@ module OpenTracing
       end
     end
 
-    # Extract a span from a carrier
-    # @param operation_name [String]
+    # Extract a SpanContext in the given format from the given carrier.
+    #
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
-    # @param carrier [Carrier]
-    # @param tracer [Tracer] the tracer the span will be attached to (for finish)
-    # @return [Span]
-    def extract(operation_name, format, carrier)
+    # @param carrier [Carrier] The carrier type dictated by the specified format
+    # @return [SpanContext] the extracted SpanContext or nil if none could be found
+    def extract(format, carrier)
       case format
       when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK
         return SpanContext::NOOP_INSTANCE

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -11,15 +11,15 @@ module OpenTracing
     # @param start_time [Time] When the Span started, if not now
     # @param tags [Hash] Tags to assign to the Span at start time
     # @return [Span] The newly-started Span
-    def start_span(operation_name, child_of: nil, start_time: nil, tags: nil)
+    def start_span(operation_name, child_of: nil, start_time: Time.now, tags: nil)
       Span::NOOP_INSTANCE
     end
 
     # Inject a SpanContext into the given carrier
     #
-    # @param spancontext [SpanContext]
+    # @param span_context [SpanContext]
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
-    # @param carrier [Hash]
+    # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
     def inject(span_context, format, carrier)
       case format
       when OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK
@@ -32,7 +32,7 @@ module OpenTracing
     # Extract a SpanContext in the given format from the given carrier.
     #
     # @param format [OpenTracing::FORMAT_TEXT_MAP, OpenTracing::FORMAT_BINARY, OpenTracing::FORMAT_RACK]
-    # @param carrier [Carrier] The carrier type dictated by the specified format
+    # @param carrier [Carrier] A carrier object of the type dictated by the specified `format`
     # @return [SpanContext] the extracted SpanContext or nil if none could be found
     def extract(format, carrier)
       case format

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -27,20 +27,20 @@ class TracerTest < Minitest::Test
   end
 
   def test_extract_text_map
-    span = tracer.extract("operation_name", OpenTracing::FORMAT_TEXT_MAP, {})
+    span = tracer.extract(OpenTracing::FORMAT_TEXT_MAP, {})
   end
 
   def test_extract_binary
-    tracer.extract(nil, OpenTracing::FORMAT_BINARY, nil)
+    tracer.extract(OpenTracing::FORMAT_BINARY, nil)
   end
 
   def test_extract_rack
-    tracer.extract("operation_name", OpenTracing::FORMAT_RACK, {})
+    tracer.extract(OpenTracing::FORMAT_RACK, {})
   end
 
   def test_extract_unknown
     assert_warn "Unknown extract format\n" do
-      tracer.extract(nil, 999, nil)
+      tracer.extract(999, nil)
     end
   end
 


### PR DESCRIPTION
Basically:
- `#inject` comments were OOD
- `#extract` semantics were OOD (took an operation name, returned a Span rather than SpanContext)
- format comments were incomplete and/or misleading

There is still more left in the OT spec beyond what's here (namely support for FollowsFrom references), but I've focused only on getting rid of API surface area that deviates from the OT spec. (I.e., future compliance changes would be backwards-compatible)