### PR TITLE
Forward inject and extract calls to global tracer

### DIFF
--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -30,8 +30,8 @@ module OpenTracing
 
   class << self
     extend Forwardable
-    # Global tracer to be used when OpenTracing.start_span is called
+    # Global tracer to be used when OpenTracing.start_span, inject or extract is called
     attr_accessor :global_tracer
-    def_delegator :global_tracer, :start_span
+    def_delegators :global_tracer, :start_span, :inject, :extract
   end
 end

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -2,13 +2,47 @@ require 'test_helper'
 require 'net/http'
 
 class OpenTracingTest < Minitest::Test
-  def test_global_tracer
+  def setup
+    @original_global_tracer = OpenTracing.global_tracer
+  end
+
+  def teardown
+    OpenTracing.global_tracer = @original_global_tracer
+  end
+
+  def test_global_tracer_is_nil_by_default
     assert_nil OpenTracing.global_tracer
+  end
+
+  def test_global_tracer_start_span
     tracer = Minitest::Mock.new
     OpenTracing.global_tracer = tracer
 
     span = Minitest::Mock.new
     tracer.expect(:start_span, span, ["span"])
-    span = OpenTracing.start_span("span")
+    OpenTracing.start_span("span")
+  end
+
+  def test_global_tracer_inject
+    tracer = Minitest::Mock.new
+    OpenTracing.global_tracer = tracer
+
+    span_context = Minitest::Mock.new
+    format = Minitest::Mock.new
+    carrier = Minitest::Mock.new
+
+    tracer.expect(:inject, nil, [span_context, format, carrier])
+    OpenTracing.inject(span_context, format, carrier)
+  end
+
+  def test_global_tracer_extract
+    tracer = Minitest::Mock.new
+    OpenTracing.global_tracer = tracer
+
+    format = Minitest::Mock.new
+    carrier = Minitest::Mock.new
+
+    tracer.expect(:extract, nil, [format, carrier])
+    OpenTracing.extract(format, carrier)
   end
 end

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -30,6 +30,8 @@ class SpanTest < Minitest::Test
   private
 
   def span
-    OpenTracing::Span.new(tracer: Minitest::Mock.new, context: OpenTracing::SpanContext.new())
+    tracer = Minitest::Mock.new
+    context = OpenTracing::SpanContext.new
+    OpenTracing::Span.new(tracer, context)
   end
 end


### PR DESCRIPTION
Currently only OpenTracing.start_span is forwarded.
OpenTracing::Trace#inject and #extract are very similar. Forwarding
these should make using OpenTracing library a bit more convenient.