### PR TITLE
Add follows_from option to Tracer#start_span

### DIFF
--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -2,6 +2,7 @@ require "forwardable"
 require "opentracing/version"
 require "opentracing/span_context"
 require "opentracing/span"
+require "opentracing/reference"
 require "opentracing/tracer"
 
 module OpenTracing

--- a/lib/opentracing/reference.rb
+++ b/lib/opentracing/reference.rb
@@ -1,0 +1,88 @@
+module OpenTracing
+  class Reference
+    CHILD_OF = 'child_of'.freeze
+    FOLLOWS_FROM = 'follows_from'.freeze
+
+    # @param context [SpanContext, Span] child_of context refers to a
+    #   parent Span that caused *and* somehow depends upon the new child Span.
+    #   Often (but not always), the parent Span cannot finish until the child
+    #   Span does.
+    #
+    #   An timing diagram for a child Span that is blocked on the new Span:
+    #
+    #     [-Parent Span----------]
+    #          [-Child Span----]
+    #
+    #   See http://opentracing.io/documentation/pages/spec
+    #
+    # @return [Reference] a ChildOf reference
+    #
+    # @example
+    #   root_span = OpenTracing.start_span('root operation')
+    #   child_span = OpenTracing.start_span('child operation', references: [
+    #     OpenTracing::Reference.child_of(root_span)
+    #   ])
+    #
+    def self.child_of(context)
+      if context.is_a?(Span)
+        context = context.context
+      end
+
+      Reference.new(CHILD_OF, context)
+    end
+
+    # @param context [SpanContext, Span] follows_from context refers to a
+    #   parent Span that does not depend in any way on the result of the new
+    #   child Span. For instance, one might use FollowsFrom Span to describe
+    #   pipeline stages separated by queues, or a fire-and-forget cache insert
+    #   at the tail end of a web request.
+    #
+    #   A FollowsFrom Span is part of the same logical trace as the new Span:
+    #   i.e., the new Span is somehow caused by the work of its FollowsFrom
+    #   Span.
+    #
+    #   All of the following could be valid timing diagrams for children that
+    #   "FollowFrom" a parent:
+    #
+    #     [-Parent Span--]  [-Child Span-]
+    #
+    #     [-Parent Span--]
+    #      [-Child Span-]
+    #
+    #     [-Parent Span-]
+    #                [-Child Span-]
+    #
+    #   See http://opentracing.io/documentation/pages/spec
+    #
+    # @return [Reference] a FollowsFrom reference
+    #
+    # @example
+    #   context = OpenTracing.extract(OpenTracing::FORMAT_RACK, rack_env)
+    #   span = OpenTracing.start_span('following operation', references: [
+    #     OpenTracing::Reference.follows_from(context)
+    #   ])
+    #
+    def self.follows_from(context)
+      if context.is_a?(Span)
+        context = context.context
+      end
+
+      Reference.new(FOLLOWS_FROM, context)
+    end
+
+    def initialize(type, context)
+      @type = type
+      @context = context
+    end
+
+    # Return [String] reference type
+    def type
+      @type
+    end
+
+    # @return [SpanContext] the context of a span this reference is referencing
+    def context
+      @context
+    end
+  end
+end

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -1,17 +1,50 @@
 module OpenTracing
   class Tracer
-    # TODO(bhs): Support FollowsFrom and multiple references
-
     # Starts a new span.
     #
     # @param operation_name [String] The operation name for the Span
-    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
-    #        the newly-started Span. If a Span instance is provided, its
-    #        context is automatically substituted.
+    #
+    # @param child_of [SpanContext, Span] child_of (ChildOf) refers to a
+    #   parent Span that caused *and* somehow depends upon the new child Span.
+    #   Often (but not always), the parent Span cannot finish until the child
+    #   Span does.
+    #
+    #   An timing diagram for a child Span that is blocked on the new Span:
+    #
+    #     [-Parent Span----------]
+    #          [-Child Span----]
+    #
+    #   See http://opentracing.io/documentation/pages/spec
+    #
+    # @param follows_from [SpanContext, Span] follows_from (FollowsFrom)
+    #   refers to a parent Span that does not depend in any way on the result
+    #   of the new child Span. For instance, one might use FollowsFrom Span to
+    #   describe pipeline stages separated by queues, or a fire-and-forget
+    #   cache insert at the tail end of a web request.
+    #
+    #   A FollowsFrom Span is part of the same logical trace as the new Span:
+    #   i.e., the new Span is somehow caused by the work of its FollowsFrom
+    #   Span.
+    #
+    #   All of the following could be valid timing diagrams for children that
+    #   "FollowFrom" a parent:
+    #
+    #     [-Parent Span--]  [-Child Span-]
+    #
+    #     [-Parent Span--]
+    #      [-Child Span-]
+    #
+    #     [-Parent Span-]
+    #                [-Child Span-]
+    #
+    #   See http://opentracing.io/documentation/pages/spec
+    #
     # @param start_time [Time] When the Span started, if not now
+    #
     # @param tags [Hash] Tags to assign to the Span at start time
+    #
     # @return [Span] The newly-started Span
-    def start_span(operation_name, child_of: nil, start_time: Time.now, tags: nil)
+    def start_span(operation_name, child_of: nil, follows_from: nil, start_time: Time.now, tags: nil)
       Span::NOOP_INSTANCE
     end
 

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -4,47 +4,22 @@ module OpenTracing
     #
     # @param operation_name [String] The operation name for the Span
     #
-    # @param child_of [SpanContext, Span] child_of (ChildOf) refers to a
-    #   parent Span that caused *and* somehow depends upon the new child Span.
-    #   Often (but not always), the parent Span cannot finish until the child
-    #   Span does.
+    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        context is automatically substituted. See [Reference] for more
+    #        information.
     #
-    #   An timing diagram for a child Span that is blocked on the new Span:
+    #   If specified, the `references` paramater must be omitted.
     #
-    #     [-Parent Span----------]
-    #          [-Child Span----]
-    #
-    #   See http://opentracing.io/documentation/pages/spec
-    #
-    # @param follows_from [SpanContext, Span] follows_from (FollowsFrom)
-    #   refers to a parent Span that does not depend in any way on the result
-    #   of the new child Span. For instance, one might use FollowsFrom Span to
-    #   describe pipeline stages separated by queues, or a fire-and-forget
-    #   cache insert at the tail end of a web request.
-    #
-    #   A FollowsFrom Span is part of the same logical trace as the new Span:
-    #   i.e., the new Span is somehow caused by the work of its FollowsFrom
-    #   Span.
-    #
-    #   All of the following could be valid timing diagrams for children that
-    #   "FollowFrom" a parent:
-    #
-    #     [-Parent Span--]  [-Child Span-]
-    #
-    #     [-Parent Span--]
-    #      [-Child Span-]
-    #
-    #     [-Parent Span-]
-    #                [-Child Span-]
-    #
-    #   See http://opentracing.io/documentation/pages/spec
+    # @param references [Array<Reference>] An array of reference
+    #   objects that identify one or more parent SpanContexts.
     #
     # @param start_time [Time] When the Span started, if not now
     #
     # @param tags [Hash] Tags to assign to the Span at start time
     #
     # @return [Span] The newly-started Span
-    def start_span(operation_name, child_of: nil, follows_from: nil, start_time: Time.now, tags: nil)
+    def start_span(operation_name, child_of: nil, references: nil, start_time: Time.now, tags: nil)
       Span::NOOP_INSTANCE
     end
 

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class ReferenceTest < Minitest::Test
+  def test_child_of_using_span
+    span = OpenTracing::Tracer.new.start_span('operation_name')
+    reference = OpenTracing::Reference.child_of(span)
+    assert_equal reference.type, OpenTracing::Reference::CHILD_OF
+    assert_equal reference.context, span.context
+  end
+
+  def test_child_of_using_span_context
+    context = OpenTracing::Tracer.new.start_span('operation_name').context
+    reference = OpenTracing::Reference.child_of(context)
+    assert_equal reference.type, OpenTracing::Reference::CHILD_OF
+    assert_equal reference.context, context
+  end
+
+  def test_follows_from_using_span
+    span = OpenTracing::Tracer.new.start_span('operation_name')
+    reference = OpenTracing::Reference.follows_from(span)
+    assert_equal reference.type, OpenTracing::Reference::FOLLOWS_FROM
+    assert_equal reference.context, span.context
+  end
+
+  def test_follows_from_using_span_context
+    context = OpenTracing::Tracer.new.start_span('operation_name').context
+    reference = OpenTracing::Reference.follows_from(context)
+    assert_equal reference.type, OpenTracing::Reference::FOLLOWS_FROM
+    assert_equal reference.context, context
+  end
+end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -5,6 +5,12 @@ class TracerTest < Minitest::Test
     assert_equal OpenTracing::Span::NOOP_INSTANCE, OpenTracing::Tracer.new.start_span("operation_name")
   end
 
+  def test_start_span_allows_references
+    references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
+    assert_equal OpenTracing::Span::NOOP_INSTANCE,
+      OpenTracing::Tracer.new.start_span("operation_name", references: references)
+  end
+
   def test_inject_text_map
     context = OpenTracing::SpanContext::NOOP_INSTANCE
     carrier = {}


### PR DESCRIPTION
Most of the documentation is from
https://github.com/opentracing/opentracing-go/blob/master/tracer.go#L169

@bhs I noticed that all libraries have a convenience option `childOf` but I don't think any had `followsFrom`. Instead they used `references`. Is there a reason for that?

I currently added it as a `follows_from` option similarly to the `child_of` option.