### PR TITLE
Assure that global_tracer is not nil; default to no-op tracer

### DIFF
--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -36,3 +36,6 @@ module OpenTracing
     def_delegators :global_tracer, :start_span, :inject, :extract
   end
 end
+
+# Default to the no-op tracer
+OpenTracing.global_tracer = OpenTracing::Tracer.new

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -10,8 +10,8 @@ class OpenTracingTest < Minitest::Test
     OpenTracing.global_tracer = @original_global_tracer
   end
 
-  def test_global_tracer_is_nil_by_default
-    assert_nil OpenTracing.global_tracer
+  def test_global_tracer_is_not_nil_by_default
+    assert OpenTracing.global_tracer
   end
 
   def test_global_tracer_start_span


### PR DESCRIPTION
Currently this gem boots with the global tracer (`OpenTracing.global_tracer`) uninitialized (set to `nil`).  

This causes applications with OpenTracing calls but without a selected tracer to crash.

<img width="1047" alt="screen shot 2018-01-11 at 19 42 44" src="https://user-images.githubusercontent.com/395132/34843155-f28f9e0a-f70d-11e7-85ca-aab84aaea255.png">

This scenario of not having a real tracer can occur for various reasons:

1. Removal or disabling of a tracer to debug related or unrelated issues.
2. An application that has no direct OpenTracing calls but include a library or gem (e.g. opentracing-contrib) that do

This also follows the other language implementations that set the global tracer to the no-op tracer by default ([Python](https://github.com/opentracing/opentracing-python/blob/master/opentracing/__init__.py#L39), [Go](https://github.com/opentracing/opentracing-go/blob/master/globaltracer.go#L4) & [Javascript](https://github.com/opentracing/opentracing-javascript/blob/master/src/global_tracer.ts#L51-L57)).

This PR assures that `OpenTracing.global_tracer` is set to an instance of `OpenTracing::Tracer` by default (and update tests).