### PR TITLE
Fixing serialization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ span.finish
 
 Using `Net::HTTP`:
 ```ruby
-client = Net::HTTP.new("http://myservice")
+client = Net::HTTP.new("myservice.com")
 req = Net::HTTP::Post.new("/")
 
 span = OpenTracing.start_span("my_span")


### PR DESCRIPTION
Ruby's `Net::HTTP#new` [takes a server address](https://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#method-c-new), not a full URI. 

From the docs:

> The address should be a DNS hostname or IP address, the port is the port the server operates on. If no port is given the default port for HTTP or HTTPS is used.