### PR TITLE
Clarify Ruby version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ And then execute:
 Or install it yourself as:
 
     $ gem install opentracing
+    
+`opentracing` supports Ruby 2.0+.
 
 ## Usage
 


### PR DESCRIPTION
Unless someone else is excited about supporting Ruby versions < 2, going to clarify that this supports Ruby 2.0+. Ruby 2.0 was released in early 2013.