### PR TITLE
Adapt Scope API for Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0
+* The tracer now implements the OpenTracing Scope API for in-process scope propagation([#21](https://github.com/opentracing/opentracing-ruby/pull/21))
+
 ## 0.3.2
 
 * Addressing Ruby style issues ([#14](https://github.com/opentracing/opentracing-ruby/pull/14))

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -4,6 +4,7 @@ require "opentracing/span_context"
 require "opentracing/span"
 require "opentracing/reference"
 require "opentracing/tracer"
+require "opentracing/scope"
 
 module OpenTracing
   # Text format for Tracer#inject and Tracer#extract.

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -5,6 +5,7 @@ require "opentracing/span"
 require "opentracing/reference"
 require "opentracing/tracer"
 require "opentracing/scope"
+require "opentracing/scope_manager"
 
 module OpenTracing
   # Text format for Tracer#inject and Tracer#extract.

--- a/lib/opentracing/scope.rb
+++ b/lib/opentracing/scope.rb
@@ -1,0 +1,23 @@
+module OpenTracing
+  # Scope represents an OpenTracing Scope
+  #
+  # See http://www.opentracing.io for more information.
+  class Scope
+    NOOP_INSTANCE = Scope.new.freeze
+
+    # Return the span scoped by this scope
+    #
+    # @return [Span]
+    def span
+      Span::NOOP_INSTANCE
+    end
+
+    # Mark the end of the active period for the current thread and scope,
+    # updating the ScopeManager#active() in the process.
+    #
+    # NOTE: Calling close more than once on a single scope instance leads to
+    # undefined behavior.
+    def close
+    end
+  end
+end

--- a/lib/opentracing/scope.rb
+++ b/lib/opentracing/scope.rb
@@ -5,17 +5,17 @@ module OpenTracing
   class Scope
     NOOP_INSTANCE = Scope.new.freeze
 
-    # Return the span scoped by this scope
+    # Return the Span scoped by this Scope
     #
     # @return [Span]
     def span
       Span::NOOP_INSTANCE
     end
 
-    # Mark the end of the active period for the current thread and scope,
-    # updating the ScopeManager#active() in the process.
+    # Mark the end of the active period for the current thread and Scope,
+    # updating the ScopeManager#active in the process.
     #
-    # NOTE: Calling close more than once on a single scope instance leads to
+    # NOTE: Calling close more than once on a single Scope instance leads to
     # undefined behavior.
     def close
     end

--- a/lib/opentracing/scope_manager.rb
+++ b/lib/opentracing/scope_manager.rb
@@ -8,6 +8,7 @@ module OpenTracing
   # ScopeManager#active
 
   class ScopeManager
+    NOOP_INSTANCE = ScopeManager.new.freeze
 
     # Make a span instance active.
     #

--- a/lib/opentracing/scope_manager.rb
+++ b/lib/opentracing/scope_manager.rb
@@ -26,8 +26,8 @@ module OpenTracing
     # currently active Span.
     #
     # If there is a non-null Scope, its wrapped Span becomes an implicit parent
-    # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active or
-    # Tracer#start time.
+    # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active_span
+    # or Tracer#start_span time.
     def active
       Scope::NOOP_INSTANCE
     end

--- a/lib/opentracing/scope_manager.rb
+++ b/lib/opentracing/scope_manager.rb
@@ -1,0 +1,34 @@
+module OpenTracing
+  # ScopeManager represents an OpenTracing ScopeManager
+  #
+  # See http://www.opentracing.io for more information.
+
+  # The ScopeManager interface abstracts both the activation of Span instances
+  # via ScopeManager#activate and access to an active Span/Scope via
+  # ScopeManager#active
+
+  class ScopeManager
+
+    # Make a span instance active.
+    #
+    # @param span [Span] the span that should become active
+    # @param finish_on_close [Boolean] whether span should automatically be
+    #   finished when Scope#close is called
+    # @return [Scope] instance to control the end of the active period for the
+    #  Span. It is a programming error to neglect to call Scope#close on the
+    #  returned instance.
+    def activate(span, finish_on_close: true)
+      Scope::NOOP_INSTANCE
+    end
+
+    # @return [Span] the currently active scope which can be used to access the
+    # currently active span.
+    #
+    # If there is a non-null scope, its wrapped span becomes an implicit parent
+    # (as Reference#CHILD_OF) of any newly-created span at Tracer#start_active or
+    # Tracer#start time.
+    def active
+      Scope::NOOP_INSTANCE
+    end
+  end
+end

--- a/lib/opentracing/scope_manager.rb
+++ b/lib/opentracing/scope_manager.rb
@@ -2,7 +2,7 @@ module OpenTracing
   # ScopeManager represents an OpenTracing ScopeManager
   #
   # See http://www.opentracing.io for more information.
-
+  #
   # The ScopeManager interface abstracts both the activation of Span instances
   # via ScopeManager#activate and access to an active Span/Scope via
   # ScopeManager#active
@@ -12,8 +12,8 @@ module OpenTracing
 
     # Make a span instance active.
     #
-    # @param span [Span] the span that should become active
-    # @param finish_on_close [Boolean] whether span should automatically be
+    # @param span [Span] the Span that should become active
+    # @param finish_on_close [Boolean] whether the Span should automatically be
     #   finished when Scope#close is called
     # @return [Scope] instance to control the end of the active period for the
     #  Span. It is a programming error to neglect to call Scope#close on the
@@ -22,11 +22,11 @@ module OpenTracing
       Scope::NOOP_INSTANCE
     end
 
-    # @return [Span] the currently active scope which can be used to access the
-    # currently active span.
+    # @return [Scope] the currently active Scope which can be used to access the
+    # currently active Span.
     #
-    # If there is a non-null scope, its wrapped span becomes an implicit parent
-    # (as Reference#CHILD_OF) of any newly-created span at Tracer#start_active or
+    # If there is a non-null Scope, its wrapped Span becomes an implicit parent
+    # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active or
     # Tracer#start time.
     def active
       Scope::NOOP_INSTANCE

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -28,6 +28,9 @@ module OpenTracing
     #   References#CHILD_OF reference to the ScopeManager#active.
     # @param finish_on_close [Boolean] whether span should automatically be
     #   finished when Scope#close is called
+    # @yield [Scope] If an optional block is passed to start_active it will
+    #   yield the newly-started Scope. If `finish_on_close` is true then the
+    #   Span will be finished automatically after the block is executed.
     # @return [Scope] The newly-started and activated Scope
     def start_active(operation_name,
                      child_of: nil,
@@ -36,7 +39,9 @@ module OpenTracing
                      tags: nil,
                      ignore_active_scope: false,
                      finish_on_close: true)
-      Scope::NOOP_INSTANCE
+      Scope::NOOP_INSTANCE.tap do |scope|
+        yield scope if block_given?
+      end
     end
 
     # Like #start_active, but the returned Span has not been registered via the

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -32,19 +32,19 @@ module OpenTracing
     #   yield the newly-started Scope. If `finish_on_close` is true then the
     #   Span will be finished automatically after the block is executed.
     # @return [Scope] The newly-started and activated Scope
-    def start_active(operation_name,
-                     child_of: nil,
-                     references: nil,
-                     start_time: Time.now,
-                     tags: nil,
-                     ignore_active_scope: false,
-                     finish_on_close: true)
+    def start_active_span(operation_name,
+                          child_of: nil,
+                          references: nil,
+                          start_time: Time.now,
+                          tags: nil,
+                          ignore_active_scope: false,
+                          finish_on_close: true)
       Scope::NOOP_INSTANCE.tap do |scope|
         yield scope if block_given?
       end
     end
 
-    # Like #start_active, but the returned Span has not been registered via the
+    # Like #start_active_span, but the returned Span has not been registered via the
     # ScopeManager.
     #
     # @param operation_name [String] The operation name for the Span
@@ -62,37 +62,12 @@ module OpenTracing
     #   References#CHILD_OF reference to the ScopeManager#active.
     # @return [Span] the newly-started Span instance, which has not been
     #   automatically registered via the ScopeManager
-    def start(operation_name,
-              child_of: nil,
-              references: nil,
-              start_time: Time.now,
-              tags: nil,
-              ignore_active_scope: false)
-      Span::NOOP_INSTANCE
-    end
-
-    # Starts a new span.
-    #
-    # @deprecated Use {#start_active} or {#start} instead.
-    #
-    # @param operation_name [String] The operation name for the Span
-    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
-    #        the newly-started Span. If a Span instance is provided, its
-    #        context is automatically substituted. See [Reference] for more
-    #        information.
-    #
-    #   If specified, the `references` paramater must be omitted.
-    # @param references [Array<Reference>] An array of reference
-    #   objects that identify one or more parent SpanContexts.
-    # @param start_time [Time] When the Span started, if not now
-    # @param tags [Hash] Tags to assign to the Span at start time
-    # @return [Span] The newly-started Span
     def start_span(operation_name,
                    child_of: nil,
                    references: nil,
                    start_time: Time.now,
-                   tags: nil)
-      warn 'Tracer#start_span is deprecated and will be removed from opentracing-ruby'
+                   tags: nil,
+                   ignore_active_scope: false)
       Span::NOOP_INSTANCE
     end
 

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -1,25 +1,93 @@
 module OpenTracing
   class Tracer
-    # Starts a new span.
+    # @return [ScopeManager] the current ScopeManager, which may be a no-op but
+    #   may not be nil.
+    def scope_manager
+      ScopeManager::NOOP_INSTANCE
+    end
+
+    # Returns a newly started and activated Scope.
+    #
+    # If the Tracer's ScopeManager#active is not nil, no explicit references
+    # are provided, and `ignore_active_scope` is false, then an inferred
+    # References#CHILD_OF reference is created to the ScopeManager#active's
+    # SpanContext when start_active is invoked.
     #
     # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        context is automatically substituted. See [Reference] for more
+    #        information.
     #
+    #   If specified, the `references` parameter must be omitted.
+    # @param references [Array<Reference>] An array of reference
+    #   objects that identify one or more parent SpanContexts.
+    # @param start_time [Time] When the Span started, if not now
+    # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
+    # @param finish_on_close [Boolean] whether span should automatically be
+    #   finished when Scope#close is called
+    # @return [Scope] The newly-started and activated Scope
+    def start_active(operation_name,
+                     child_of: nil,
+                     references: nil,
+                     start_time: Time.now,
+                     tags: nil,
+                     ignore_active_scope: false,
+                     finish_on_close: true)
+      Scope::NOOP_INSTANCE
+    end
+
+    # Like #start_active, but the returned Span has not been registered via the
+    # ScopeManager.
+    #
+    # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        context is automatically substituted. See [Reference] for more
+    #        information.
+    #
+    #   If specified, the `references` parameter must be omitted.
+    # @param references [Array<Reference>] An array of reference
+    #   objects that identify one or more parent SpanContexts.
+    # @param start_time [Time] When the Span started, if not now
+    # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
+    # @return [Span] the newly-started Span instance, which has not been
+    #   automatically registered via the ScopeManager
+    def start(operation_name,
+              child_of: nil,
+              references: nil,
+              start_time: Time.now,
+              tags: nil,
+              ignore_active_scope: false)
+      Span::NOOP_INSTANCE
+    end
+
+    # Starts a new span.
+    #
+    # @deprecated Use {#start_active} or {#start} instead.
+    #
+    # @param operation_name [String] The operation name for the Span
     # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
     #        the newly-started Span. If a Span instance is provided, its
     #        context is automatically substituted. See [Reference] for more
     #        information.
     #
     #   If specified, the `references` paramater must be omitted.
-    #
     # @param references [Array<Reference>] An array of reference
     #   objects that identify one or more parent SpanContexts.
-    #
     # @param start_time [Time] When the Span started, if not now
-    #
     # @param tags [Hash] Tags to assign to the Span at start time
-    #
     # @return [Span] The newly-started Span
-    def start_span(operation_name, child_of: nil, references: nil, start_time: Time.now, tags: nil)
+    def start_span(operation_name,
+                   child_of: nil,
+                   references: nil,
+                   start_time: Time.now,
+                   tags: nil)
+      warn 'Tracer#start_span is deprecated and will be removed from opentracing-ruby'
       Span::NOOP_INSTANCE
     end
 

--- a/lib/opentracing/version.rb
+++ b/lib/opentracing/version.rb
@@ -1,3 +1,3 @@
 module OpenTracing
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -2,28 +2,28 @@ require 'test_helper'
 
 class ReferenceTest < Minitest::Test
   def test_child_of_using_span
-    span = OpenTracing::Tracer.new.start_span('operation_name')
+    span = OpenTracing::Tracer.new.start_active('operation_name').span
     reference = OpenTracing::Reference.child_of(span)
     assert_equal reference.type, OpenTracing::Reference::CHILD_OF
     assert_equal reference.context, span.context
   end
 
   def test_child_of_using_span_context
-    context = OpenTracing::Tracer.new.start_span('operation_name').context
+    context = OpenTracing::Tracer.new.start_active('operation_name').span.context
     reference = OpenTracing::Reference.child_of(context)
     assert_equal reference.type, OpenTracing::Reference::CHILD_OF
     assert_equal reference.context, context
   end
 
   def test_follows_from_using_span
-    span = OpenTracing::Tracer.new.start_span('operation_name')
+    span = OpenTracing::Tracer.new.start_active('operation_name').span
     reference = OpenTracing::Reference.follows_from(span)
     assert_equal reference.type, OpenTracing::Reference::FOLLOWS_FROM
     assert_equal reference.context, span.context
   end
 
   def test_follows_from_using_span_context
-    context = OpenTracing::Tracer.new.start_span('operation_name').context
+    context = OpenTracing::Tracer.new.start_active('operation_name').span.context
     reference = OpenTracing::Reference.follows_from(context)
     assert_equal reference.type, OpenTracing::Reference::FOLLOWS_FROM
     assert_equal reference.context, context

--- a/test/reference_test.rb
+++ b/test/reference_test.rb
@@ -2,28 +2,28 @@ require 'test_helper'
 
 class ReferenceTest < Minitest::Test
   def test_child_of_using_span
-    span = OpenTracing::Tracer.new.start_active('operation_name').span
+    span = OpenTracing::Tracer.new.start_span('operation_name')
     reference = OpenTracing::Reference.child_of(span)
     assert_equal reference.type, OpenTracing::Reference::CHILD_OF
     assert_equal reference.context, span.context
   end
 
   def test_child_of_using_span_context
-    context = OpenTracing::Tracer.new.start_active('operation_name').span.context
+    context = OpenTracing::Tracer.new.start_span('operation_name').context
     reference = OpenTracing::Reference.child_of(context)
     assert_equal reference.type, OpenTracing::Reference::CHILD_OF
     assert_equal reference.context, context
   end
 
   def test_follows_from_using_span
-    span = OpenTracing::Tracer.new.start_active('operation_name').span
+    span = OpenTracing::Tracer.new.start_span('operation_name')
     reference = OpenTracing::Reference.follows_from(span)
     assert_equal reference.type, OpenTracing::Reference::FOLLOWS_FROM
     assert_equal reference.context, span.context
   end
 
   def test_follows_from_using_span_context
-    context = OpenTracing::Tracer.new.start_active('operation_name').span.context
+    context = OpenTracing::Tracer.new.start_span('operation_name').context
     reference = OpenTracing::Reference.follows_from(context)
     assert_equal reference.type, OpenTracing::Reference::FOLLOWS_FROM
     assert_equal reference.context, context

--- a/test/scope_manager_test.rb
+++ b/test/scope_manager_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module OpenTracing
+  class ScopeManagerTest < Minitest::Test
+    def setup
+      @scope_manager = ScopeManager.new
+    end
+
+    def test_activate
+      span = Span::NOOP_INSTANCE
+      scope = @scope_manager.activate(span)
+      assert_equal span, scope.span
+    end
+
+    def test_active
+      span = Span::NOOP_INSTANCE
+      scope = @scope_manager.activate(span)
+      assert_equal scope, @scope_manager.active
+    end
+  end
+end

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module OpenTracing
+  class ScopeTest < Minitest::Test
+    def test_span
+      span = Span::NOOP_INSTANCE
+      scope = Scope.new
+      assert_equal span, scope.span
+    end
+
+    def test_close
+      scope = Scope.new
+      scope.close
+    end
+  end
+end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -34,6 +34,13 @@ class TracerTest < Minitest::Test
     assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
   end
 
+  def test_start_active_accepts_block
+    OpenTracing::Tracer.new.start_active("operation_name") do |scope|
+      assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+      assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+    end
+  end
+
   def test_start
     span = OpenTracing::Tracer.new.start("operation_name")
     assert_equal OpenTracing::Span::NOOP_INSTANCE, span

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -2,54 +2,33 @@ require 'test_helper'
 
 class TracerTest < Minitest::Test
   def test_start_span
-    silence_logger do
-      assert_equal OpenTracing::Span::NOOP_INSTANCE, OpenTracing::Tracer.new.start_span("operation_name")
-    end
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, OpenTracing::Tracer.new.start_span("operation_name")
   end
 
   def test_start_span_allows_references
-    silence_logger do
-      references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
-      assert_equal OpenTracing::Span::NOOP_INSTANCE,
-        OpenTracing::Tracer.new.start_span("operation_name", references: references)
-      end
-  end
-
-  def test_start_span_deprecated
-    assert_warn "Tracer#start_span is deprecated and will be removed from opentracing-ruby\n" do
-      OpenTracing::Tracer.new.start_span("operation_name")
-    end
-  end
-
-  def test_start_active
-    scope = OpenTracing::Tracer.new.start_active("operation_name")
-    assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
-    assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
-  end
-
-  def test_start_active_allows_references
     references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
-    scope = OpenTracing::Tracer.new.start_active("operation_name", references: references)
+    assert_equal OpenTracing::Span::NOOP_INSTANCE,
+      OpenTracing::Tracer.new.start_span("operation_name", references: references)
+  end
+
+  def test_start_active_span
+    scope = OpenTracing::Tracer.new.start_active_span("operation_name")
     assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
     assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
   end
 
-  def test_start_active_accepts_block
-    OpenTracing::Tracer.new.start_active("operation_name") do |scope|
+  def test_start_active_span_allows_references
+    references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
+    scope = OpenTracing::Tracer.new.start_active_span("operation_name", references: references)
+    assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+  end
+
+  def test_start_active_span_accepts_block
+    OpenTracing::Tracer.new.start_active_span("operation_name") do |scope|
       assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
       assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
     end
-  end
-
-  def test_start
-    span = OpenTracing::Tracer.new.start("operation_name")
-    assert_equal OpenTracing::Span::NOOP_INSTANCE, span
-  end
-
-  def test_start_allows_references
-    references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
-    span = OpenTracing::Tracer.new.start("operation_name", references: references)
-    assert_equal OpenTracing::Span::NOOP_INSTANCE, span
   end
 
   def test_inject_text_map
@@ -104,17 +83,6 @@ class TracerTest < Minitest::Test
       $stderr = str
       block.call
       assert_equal msg, str.string
-    ensure
-      $stderr = original_stderr
-    end
-  end
-
-  def silence_logger(&block)
-    original_stderr = $stderr
-    begin
-      str = StringIO.new
-      $stderr = str
-      block.call
     ensure
       $stderr = original_stderr
     end


### PR DESCRIPTION
I was reviewing the Scope API implemented in v0.31.0 of the [opentracing-java](https://github.com/opentracing/opentracing-java) project and decided to try and adapt it for Ruby. I added implementations of `Scope` and `ScopeManager` and updated the Tracer class with methods: `start_active` and `start`. This work was based heavily on the following:

* https://github.com/opentracing/opentracing-java
* https://github.com/opentracing/opentracing-python/pull/64

The work here is just a starting point. I'd be happy to address any questions, comments, or suggestions.