### PR TITLE
Deprecate log; add log_kv

### DIFF
--- a/lib/opentracing/span.rb
+++ b/lib/opentracing/span.rb
@@ -40,11 +40,20 @@ module OpenTracing
       nil
     end
 
+    # ** Deprecated **
     # Add a log entry to this span
     # @param event [String] event name for the log
     # @param timestamp [Time] time of the log
     # @param fields [Hash] Additional information to log
     def log(event: nil, timestamp: Time.now, **fields)
+      warn "Span#log is deprecated.  Please use Span#log_kv instead."
+      nil
+    end
+
+    # Add a log entry to this span
+    # @param timestamp [Time] time of the log
+    # @param fields [Hash] Additional information to log
+    def log_kv(timestamp: Time.now, **fields)
       nil
     end
 

--- a/lib/opentracing/span.rb
+++ b/lib/opentracing/span.rb
@@ -40,7 +40,10 @@ module OpenTracing
       nil
     end
 
-    # ** Deprecated **
+    # @deprecated Use {#log_kv} instead.
+    # Reason: event is an optional standard log field defined in spec and not required.  Also,
+    # method name {#log_kv} is more consistent with other language implementations such as Python and Go.
+    #
     # Add a log entry to this span
     # @param event [String] event name for the log
     # @param timestamp [Time] time of the log

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -35,18 +35,6 @@ class SpanTest < Minitest::Test
   end
 
   private
-  def assert_warn(msg, &block)
-    original_stderr = $stderr
-    begin
-      str = StringIO.new
-      $stderr = str
-      block.call
-      assert_equal msg, str.string
-    ensure
-      $stderr = original_stderr
-    end
-  end
-
   def span
     OpenTracing::Span.new
   end

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -19,8 +19,15 @@ class SpanTest < Minitest::Test
     assert_nil span.get_baggage_item(:foo)
   end
 
-  def test_log
-    assert_nil span.log(event: "event", timestamp: Time.now, foo: "bar")
+  def test_log_deprecated
+    assert_warn "Span#log is deprecated.  Please use Span#log_kv instead.\n" do
+      assert_nil span.log(event: "event", timestamp: Time.now, foo: "bar")
+    end
+  end
+
+
+  def test_log_kv
+    assert_nil span.log_kv(timestamp: Time.now, foo: "bar")
   end
 
   def test_finish
@@ -28,6 +35,17 @@ class SpanTest < Minitest::Test
   end
 
   private
+  def assert_warn(msg, &block)
+    original_stderr = $stderr
+    begin
+      str = StringIO.new
+      $stderr = str
+      block.call
+      assert_equal msg, str.string
+    ensure
+      $stderr = original_stderr
+    end
+  end
 
   def span
     OpenTracing::Span.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,16 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'opentracing'
 
 require 'minitest/autorun'
+
+
+def assert_warn(msg, &block)
+  original_stderr = $stderr
+  begin
+    str = StringIO.new
+    $stderr = str
+    block.call
+    assert_equal msg, str.string
+  ensure
+    $stderr = original_stderr
+  end
+end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -51,19 +51,6 @@ class TracerTest < Minitest::Test
   end
 
   private
-
-  def assert_warn(msg, &block)
-    original_stderr = $stderr
-    begin
-      str = StringIO.new
-      $stderr = str
-      block.call
-      assert_equal msg, str.string
-    ensure
-      $stderr = original_stderr
-    end
-  end
-
   def tracer
     OpenTracing::Tracer.new
   end


### PR DESCRIPTION
PR for issue #22 

@itsderek23 @mwear I moved the `assert_warn` method to `test_helper` for sharing.  There is a [structured_warnings](https://github.com/schmidt/structured_warnings) gem with more support warning methods.  I don't think we need the gem for now but I can include it in the PR if that makes sense.
