### PR TITLE
v0.4.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## 0.4.0
+
 * The tracer now implements the OpenTracing Scope API for in-process scope propagation([#21](https://github.com/opentracing/opentracing-ruby/pull/21))
+* Adds a `log_kv` method and deprecates `log` for consistency with other language implementations. See [#22](https://github.com/opentracing/opentracing-ruby/pull/23).
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0
+* The tracer now implements the OpenTracing Scope API for in-process scope propagation([#21](https://github.com/opentracing/opentracing-ruby/pull/21))
+
 ## 0.3.2
 
 * Addressing Ruby style issues ([#14](https://github.com/opentracing/opentracing-ruby/pull/14))

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -4,6 +4,8 @@ require "opentracing/span_context"
 require "opentracing/span"
 require "opentracing/reference"
 require "opentracing/tracer"
+require "opentracing/scope"
+require "opentracing/scope_manager"
 
 module OpenTracing
   # Text format for Tracer#inject and Tracer#extract.

--- a/lib/opentracing/scope.rb
+++ b/lib/opentracing/scope.rb
@@ -1,0 +1,23 @@
+module OpenTracing
+  # Scope represents an OpenTracing Scope
+  #
+  # See http://www.opentracing.io for more information.
+  class Scope
+    NOOP_INSTANCE = Scope.new.freeze
+
+    # Return the Span scoped by this Scope
+    #
+    # @return [Span]
+    def span
+      Span::NOOP_INSTANCE
+    end
+
+    # Mark the end of the active period for the current thread and Scope,
+    # updating the ScopeManager#active in the process.
+    #
+    # NOTE: Calling close more than once on a single Scope instance leads to
+    # undefined behavior.
+    def close
+    end
+  end
+end

--- a/lib/opentracing/scope_manager.rb
+++ b/lib/opentracing/scope_manager.rb
@@ -1,0 +1,35 @@
+module OpenTracing
+  # ScopeManager represents an OpenTracing ScopeManager
+  #
+  # See http://www.opentracing.io for more information.
+  #
+  # The ScopeManager interface abstracts both the activation of Span instances
+  # via ScopeManager#activate and access to an active Span/Scope via
+  # ScopeManager#active
+
+  class ScopeManager
+    NOOP_INSTANCE = ScopeManager.new.freeze
+
+    # Make a span instance active.
+    #
+    # @param span [Span] the Span that should become active
+    # @param finish_on_close [Boolean] whether the Span should automatically be
+    #   finished when Scope#close is called
+    # @return [Scope] instance to control the end of the active period for the
+    #  Span. It is a programming error to neglect to call Scope#close on the
+    #  returned instance.
+    def activate(span, finish_on_close: true)
+      Scope::NOOP_INSTANCE
+    end
+
+    # @return [Scope] the currently active Scope which can be used to access the
+    # currently active Span.
+    #
+    # If there is a non-null Scope, its wrapped Span becomes an implicit parent
+    # (as Reference#CHILD_OF) of any newly-created Span at Tracer#start_active_span
+    # or Tracer#start_span time.
+    def active
+      Scope::NOOP_INSTANCE
+    end
+  end
+end

--- a/lib/opentracing/span.rb
+++ b/lib/opentracing/span.rb
@@ -40,11 +40,23 @@ module OpenTracing
       nil
     end
 
+    # @deprecated Use {#log_kv} instead.
+    # Reason: event is an optional standard log field defined in spec and not required.  Also,
+    # method name {#log_kv} is more consistent with other language implementations such as Python and Go.
+    #
     # Add a log entry to this span
     # @param event [String] event name for the log
     # @param timestamp [Time] time of the log
     # @param fields [Hash] Additional information to log
     def log(event: nil, timestamp: Time.now, **fields)
+      warn "Span#log is deprecated.  Please use Span#log_kv instead."
+      nil
+    end
+
+    # Add a log entry to this span
+    # @param timestamp [Time] time of the log
+    # @param fields [Hash] Additional information to log
+    def log_kv(timestamp: Time.now, **fields)
       nil
     end
 

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -1,25 +1,73 @@
 module OpenTracing
   class Tracer
-    # Starts a new span.
+    # @return [ScopeManager] the current ScopeManager, which may be a no-op but
+    #   may not be nil.
+    def scope_manager
+      ScopeManager::NOOP_INSTANCE
+    end
+
+    # Returns a newly started and activated Scope.
+    #
+    # If the Tracer's ScopeManager#active is not nil, no explicit references
+    # are provided, and `ignore_active_scope` is false, then an inferred
+    # References#CHILD_OF reference is created to the ScopeManager#active's
+    # SpanContext when start_active is invoked.
     #
     # @param operation_name [String] The operation name for the Span
-    #
     # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
     #        the newly-started Span. If a Span instance is provided, its
     #        context is automatically substituted. See [Reference] for more
     #        information.
     #
-    #   If specified, the `references` paramater must be omitted.
-    #
+    #   If specified, the `references` parameter must be omitted.
     # @param references [Array<Reference>] An array of reference
     #   objects that identify one or more parent SpanContexts.
-    #
     # @param start_time [Time] When the Span started, if not now
-    #
     # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
+    # @param finish_on_close [Boolean] whether span should automatically be
+    #   finished when Scope#close is called
+    # @yield [Scope] If an optional block is passed to start_active it will
+    #   yield the newly-started Scope. If `finish_on_close` is true then the
+    #   Span will be finished automatically after the block is executed.
+    # @return [Scope] The newly-started and activated Scope
+    def start_active_span(operation_name,
+                          child_of: nil,
+                          references: nil,
+                          start_time: Time.now,
+                          tags: nil,
+                          ignore_active_scope: false,
+                          finish_on_close: true)
+      Scope::NOOP_INSTANCE.tap do |scope|
+        yield scope if block_given?
+      end
+    end
+
+    # Like #start_active_span, but the returned Span has not been registered via the
+    # ScopeManager.
     #
-    # @return [Span] The newly-started Span
-    def start_span(operation_name, child_of: nil, references: nil, start_time: Time.now, tags: nil)
+    # @param operation_name [String] The operation name for the Span
+    # @param child_of [SpanContext, Span] SpanContext that acts as a parent to
+    #        the newly-started Span. If a Span instance is provided, its
+    #        context is automatically substituted. See [Reference] for more
+    #        information.
+    #
+    #   If specified, the `references` parameter must be omitted.
+    # @param references [Array<Reference>] An array of reference
+    #   objects that identify one or more parent SpanContexts.
+    # @param start_time [Time] When the Span started, if not now
+    # @param tags [Hash] Tags to assign to the Span at start time
+    # @param ignore_active_scope [Boolean] whether to create an implicit
+    #   References#CHILD_OF reference to the ScopeManager#active.
+    # @return [Span] the newly-started Span instance, which has not been
+    #   automatically registered via the ScopeManager
+    def start_span(operation_name,
+                   child_of: nil,
+                   references: nil,
+                   start_time: Time.now,
+                   tags: nil,
+                   ignore_active_scope: false)
       Span::NOOP_INSTANCE
     end
 

--- a/lib/opentracing/version.rb
+++ b/lib/opentracing/version.rb
@@ -1,3 +1,3 @@
 module OpenTracing
-  VERSION = "0.3.2"
+  VERSION = "0.3.3.rc1"
 end

--- a/lib/opentracing/version.rb
+++ b/lib/opentracing/version.rb
@@ -1,3 +1,3 @@
 module OpenTracing
-  VERSION = "0.3.3.rc1"
+  VERSION = "0.4.0.rc1"
 end

--- a/test/scope_manager_test.rb
+++ b/test/scope_manager_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module OpenTracing
+  class ScopeManagerTest < Minitest::Test
+    def setup
+      @scope_manager = ScopeManager.new
+    end
+
+    def test_activate
+      span = Span::NOOP_INSTANCE
+      scope = @scope_manager.activate(span)
+      assert_equal span, scope.span
+    end
+
+    def test_active
+      span = Span::NOOP_INSTANCE
+      scope = @scope_manager.activate(span)
+      assert_equal scope, @scope_manager.active
+    end
+  end
+end

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module OpenTracing
+  class ScopeTest < Minitest::Test
+    def test_span
+      span = Span::NOOP_INSTANCE
+      scope = Scope.new
+      assert_equal span, scope.span
+    end
+
+    def test_close
+      scope = Scope.new
+      scope.close
+    end
+  end
+end

--- a/test/span_test.rb
+++ b/test/span_test.rb
@@ -19,8 +19,15 @@ class SpanTest < Minitest::Test
     assert_nil span.get_baggage_item(:foo)
   end
 
-  def test_log
-    assert_nil span.log(event: "event", timestamp: Time.now, foo: "bar")
+  def test_log_deprecated
+    assert_warn "Span#log is deprecated.  Please use Span#log_kv instead.\n" do
+      assert_nil span.log(event: "event", timestamp: Time.now, foo: "bar")
+    end
+  end
+
+
+  def test_log_kv
+    assert_nil span.log_kv(timestamp: Time.now, foo: "bar")
   end
 
   def test_finish
@@ -28,7 +35,6 @@ class SpanTest < Minitest::Test
   end
 
   private
-
   def span
     OpenTracing::Span.new
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,16 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'opentracing'
 
 require 'minitest/autorun'
+
+
+def assert_warn(msg, &block)
+  original_stderr = $stderr
+  begin
+    str = StringIO.new
+    $stderr = str
+    block.call
+    assert_equal msg, str.string
+  ensure
+    $stderr = original_stderr
+  end
+end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -11,6 +11,26 @@ class TracerTest < Minitest::Test
       OpenTracing::Tracer.new.start_span("operation_name", references: references)
   end
 
+  def test_start_active_span
+    scope = OpenTracing::Tracer.new.start_active_span("operation_name")
+    assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+  end
+
+  def test_start_active_span_allows_references
+    references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
+    scope = OpenTracing::Tracer.new.start_active_span("operation_name", references: references)
+    assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+  end
+
+  def test_start_active_span_accepts_block
+    OpenTracing::Tracer.new.start_active_span("operation_name") do |scope|
+      assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+      assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+    end
+  end
+
   def test_inject_text_map
     context = OpenTracing::SpanContext::NOOP_INSTANCE
     carrier = {}
@@ -48,6 +68,10 @@ class TracerTest < Minitest::Test
     assert_warn "Unknown extract format\n" do
       tracer.extract(999, nil)
     end
+  end
+
+  def test_scope_manager
+    assert_equal OpenTracing::ScopeManager::NOOP_INSTANCE, tracer.scope_manager
   end
 
   private

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -51,19 +51,6 @@ class TracerTest < Minitest::Test
   end
 
   private
-
-  def assert_warn(msg, &block)
-    original_stderr = $stderr
-    begin
-      str = StringIO.new
-      $stderr = str
-      block.call
-      assert_equal msg, str.string
-    ensure
-      $stderr = original_stderr
-    end
-  end
-
   def tracer
     OpenTracing::Tracer.new
   end


### PR DESCRIPTION
This merges #21 and #23 into a `0.4.0` branch. 

This shouldn't add any breaking changes, but I haven't tested with an actual tracer.

Released as `0.4.0.rc1` on RubyGems.

Anyone with a real-world implementation of `opentracing-ruby` mind verifying this works as desired?

