### PR TITLE
Fix global tracer delegators

### DIFF
--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -35,7 +35,8 @@ module OpenTracing
     extend Forwardable
     # Global tracer to be used when OpenTracing.start_span, inject or extract is called
     attr_accessor :global_tracer
-    def_delegators :global_tracer, :start_span, :inject, :extract
+    def_delegators :global_tracer, :scope_manager, :start_active_span,
+                   :start_span, :inject, :extract
   end
 end
 

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -14,6 +14,24 @@ class OpenTracingTest < Minitest::Test
     assert OpenTracing.global_tracer
   end
 
+  def test_global_tracer_scope_manager
+    tracer = Minitest::Mock.new
+    OpenTracing.global_tracer = tracer
+
+    scope = Minitest::Mock.new
+    tracer.expect(:scope_manager, scope)
+    OpenTracing.scope_manager
+  end
+
+  def test_global_tracer_start_active_span
+    tracer = Minitest::Mock.new
+    OpenTracing.global_tracer = tracer
+
+    scope = Minitest::Mock.new
+    tracer.expect(:start_active_span, scope, ["span"])
+    OpenTracing.start_active_span("span")
+  end
+
   def test_global_tracer_start_span
     tracer = Minitest::Mock.new
     OpenTracing.global_tracer = tracer


### PR DESCRIPTION
In version 0.3.2 there were delgators defined on the `OpenTracing` module that would forward to their respective methods on the global tracer. In 0.4.0 two new methods were added to the `Tracer` API, but the delegators were not added to the `OpenTracing` module. This PR fixes that oversight.