### PR TITLE
Add active_span convenience method to OpenTracing module

### DIFF
--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -38,6 +38,15 @@ module OpenTracing
     attr_accessor :global_tracer
     def_delegators :global_tracer, :scope_manager, :start_active_span,
                    :start_span, :inject, :extract
+
+    # Convenience method to access to currently active span. This is equivalent
+    # to calling `OpenTracing.scope_manager.active.span`
+    #
+    # @return [Span] the currently active span or Nil
+    def active_span
+      scope = scope_manager.active
+      scope.span if scope
+    end
   end
 end
 

--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -39,10 +39,10 @@ module OpenTracing
     def_delegators :global_tracer, :scope_manager, :start_active_span,
                    :start_span, :inject, :extract
 
-    # Convenience method to access to currently active span. This is equivalent
+    # Convenience method to access the currently active span. This is equivalent
     # to calling `OpenTracing.scope_manager.active.span`
     #
-    # @return [Span] the currently active span or Nil
+    # @return [Span, nil] the currently active span or nil
     def active_span
       scope = scope_manager.active
       scope.span if scope

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -70,14 +70,13 @@ class OpenTracingTest < Minitest::Test
 
     scope_manager = Minitest::Mock.new
     scope = Minitest::Mock.new
-    span = Minitest::Mock.new
+    span = OpenTracing::Span::NOOP_INSTANCE
 
     tracer.expect(:scope_manager, scope_manager)
     scope_manager.expect(:active, scope)
     scope.expect(:span, span)
 
-    OpenTracing.active_span
-
+    assert_equal span, OpenTracing.active_span
     [tracer, scope_manager, scope].map(&:verify)
   end
 end

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -63,4 +63,21 @@ class OpenTracingTest < Minitest::Test
     tracer.expect(:extract, nil, [format, carrier])
     OpenTracing.extract(format, carrier)
   end
+
+  def test_global_tracer_active_span
+    tracer = Minitest::Mock.new
+    OpenTracing.global_tracer = tracer
+
+    scope_manager = Minitest::Mock.new
+    scope = Minitest::Mock.new
+    span = Minitest::Mock.new
+
+    tracer.expect(:scope_manager, scope_manager)
+    scope_manager.expect(:active, scope)
+    scope.expect(:span, span)
+
+    OpenTracing.active_span
+
+    [tracer, scope_manager, scope].map(&:verify)
+  end
 end


### PR DESCRIPTION
This method was added based on the excellent [suggestion](https://github.com/opentracing/opentracing-ruby/pull/29#discussion_r180877729) from @indrekj  on #29.

It's a common task to have to access the currently active `Span` and it's slightly cumbersome to type: `OpenTracing.scope_manager.active.span`. With this convenience method, the currently active `Span` will be accessible through `OpenTracing.active_span`.