### PR TITLE
Verify expectations on mocks in opentracing_test

### DIFF
--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -21,6 +21,8 @@ class OpenTracingTest < Minitest::Test
     scope = Minitest::Mock.new
     tracer.expect(:scope_manager, scope)
     OpenTracing.scope_manager
+
+    tracer.verify
   end
 
   def test_global_tracer_start_active_span
@@ -30,6 +32,8 @@ class OpenTracingTest < Minitest::Test
     scope = Minitest::Mock.new
     tracer.expect(:start_active_span, scope, ['span'])
     OpenTracing.start_active_span('span')
+
+    tracer.verify
   end
 
   def test_global_tracer_start_span
@@ -39,6 +43,8 @@ class OpenTracingTest < Minitest::Test
     span = Minitest::Mock.new
     tracer.expect(:start_span, span, ['span'])
     OpenTracing.start_span('span')
+
+    tracer.verify
   end
 
   def test_global_tracer_inject
@@ -51,6 +57,8 @@ class OpenTracingTest < Minitest::Test
 
     tracer.expect(:inject, nil, [span_context, format, carrier])
     OpenTracing.inject(span_context, format, carrier)
+
+    tracer.verify
   end
 
   def test_global_tracer_extract
@@ -62,5 +70,7 @@ class OpenTracingTest < Minitest::Test
 
     tracer.expect(:extract, nil, [format, carrier])
     OpenTracing.extract(format, carrier)
+
+    tracer.verify
   end
 end

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -18,8 +18,8 @@ class OpenTracingTest < Minitest::Test
     tracer = Minitest::Mock.new
     OpenTracing.global_tracer = tracer
 
-    scope = Minitest::Mock.new
-    tracer.expect(:scope_manager, scope)
+    scope_manager = Minitest::Mock.new
+    tracer.expect(:scope_manager, scope_manager)
     OpenTracing.scope_manager
 
     tracer.verify


### PR DESCRIPTION
When working on #30, I noticed that we were not verifying expectations set on mocks. This PR fixes that. I also renamed a poorly named mock from a recently written test. The mock represents the scope_manager, but was named `scope`. I renamed it to `scope_manager` for clarity.