### PR TITLE
Add active_span method to Tracer

### DIFF
--- a/lib/opentracing.rb
+++ b/lib/opentracing.rb
@@ -37,16 +37,7 @@ module OpenTracing
     # Global tracer to be used when OpenTracing.start_span, inject or extract is called
     attr_accessor :global_tracer
     def_delegators :global_tracer, :scope_manager, :start_active_span,
-                   :start_span, :inject, :extract
-
-    # Convenience method to access the currently active span. This is equivalent
-    # to calling `OpenTracing.scope_manager.active.span`
-    #
-    # @return [Span, nil] the currently active span or nil
-    def active_span
-      scope = scope_manager.active
-      scope.span if scope
-    end
+                   :start_span, :inject, :extract, :active_span
   end
 end
 

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -12,6 +12,14 @@ module OpenTracing
       ScopeManager::NOOP_INSTANCE
     end
 
+    # @return [Span, nil] the active span. This is a shorthand for
+    #   `scope_manager.active.span`, and nil will be returned if
+    #   Scope#active is nil.
+    def active_span
+      scope = scope_manager.active
+      scope.span if scope
+    end
+
     # Returns a newly started and activated Scope.
     #
     # If the Tracer's ScopeManager#active is not nil, no explicit references

--- a/opentracing.gemspec
+++ b/opentracing.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'opentracing/version'

--- a/test/opentracing_test.rb
+++ b/test/opentracing_test.rb
@@ -78,15 +78,10 @@ class OpenTracingTest < Minitest::Test
     tracer = Minitest::Mock.new
     OpenTracing.global_tracer = tracer
 
-    scope_manager = Minitest::Mock.new
-    scope = Minitest::Mock.new
     span = OpenTracing::Span::NOOP_INSTANCE
-
-    tracer.expect(:scope_manager, scope_manager)
-    scope_manager.expect(:active, scope)
-    scope.expect(:span, span)
+    tracer.expect(:active_span, span)
 
     assert_equal span, OpenTracing.active_span
-    [tracer, scope_manager, scope].map(&:verify)
+    tracer.verify
   end
 end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -74,6 +74,10 @@ class TracerTest < Minitest::Test
     assert_equal OpenTracing::ScopeManager::NOOP_INSTANCE, tracer.scope_manager
   end
 
+  def test_active_span
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, tracer.active_span
+  end
+
   private
 
   def tracer


### PR DESCRIPTION
Previously it was only defined in OpenTracing module. Tracer#active_span
is also defined in opentracing python and java. Define it here as well
and make OpenTracing to delegate to Tracer instead.

This is useful when Tracer object is being passed around and OpenTracing
module is not used directly.

This is a backwards compatible change.