### PR TITLE
Add Tracer#start_active_scope and deprecate Tracer#start_active_span

### DIFF
--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -20,7 +20,14 @@ module OpenTracing
       scope.span if scope
     end
 
-    # Returns a newly started and activated Scope.
+    # Returns a newly started and activated Scope
+    #
+    # @deprecated Use {#start_active_scope} instead
+    def start_active_span(*args, &block)
+      start_active_scope(*args, &block)
+    end
+
+    # Returns a newly started and activated Scope
     #
     # If the Tracer's ScopeManager#active is not nil, no explicit references
     # are provided, and `ignore_active_scope` is false, then an inferred
@@ -46,13 +53,13 @@ module OpenTracing
     #   yield the newly-started Scope. If `finish_on_close` is true then the
     #   Span will be finished automatically after the block is executed.
     # @return [Scope] The newly-started and activated Scope
-    def start_active_span(operation_name,
-                          child_of: nil,
-                          references: nil,
-                          start_time: Time.now,
-                          tags: nil,
-                          ignore_active_scope: false,
-                          finish_on_close: true)
+    def start_active_scope(operation_name,
+                           child_of: nil,
+                           references: nil,
+                           start_time: Time.now,
+                           tags: nil,
+                           ignore_active_scope: false,
+                           finish_on_close: true)
       Scope::NOOP_INSTANCE.tap do |scope|
         yield scope if block_given?
       end

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -31,6 +31,26 @@ class TracerTest < Minitest::Test
     end
   end
 
+  def test_start_active_scope
+    scope = OpenTracing::Tracer.new.start_active_scope('operation_name')
+    assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+  end
+
+  def test_start_active_scope_allows_references
+    references = [OpenTracing::Reference.child_of(OpenTracing::Span::NOOP_INSTANCE)]
+    scope = OpenTracing::Tracer.new.start_active_scope('operation_name', references: references)
+    assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+    assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+  end
+
+  def test_start_active_scope_accepts_block
+    OpenTracing::Tracer.new.start_active_scope('operation_name') do |scope|
+      assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
+      assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+    end
+  end
+
   def test_inject_text_map
     context = OpenTracing::SpanContext::NOOP_INSTANCE
     carrier = {}


### PR DESCRIPTION
After some discussion in
https://github.com/opentracing/opentracing-python/pull/64#discussion_r198963857
and in the cross-language gitter, it was decided that #start_active_scope
makes more sense than #start_active_span because the return type is a
Scope, not a Span. Python and other similar languages will also change it.