### PR TITLE
Improve and fix README opentracing.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package is a Ruby platform API for OpenTracing.
 ## Required Reading
 
 In order to understand the Ruby platform API, one must first be familiar with the
-[OpenTracing project](http://opentracing.io) and
+[OpenTracing project](https://opentracing.io) and
 [terminology](https://opentracing.io/docs/overview/) more specifically.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is a Ruby platform API for OpenTracing.
 
 In order to understand the Ruby platform API, one must first be familiar with the
 [OpenTracing project](http://opentracing.io) and
-[terminology](http://opentracing.io/documentation/pages/spec.html) more specifically.
+[terminology](https://opentracing.io/docs/overview/) more specifically.
 
 ## Installation
 


### PR DESCRIPTION
While checking this README I realized that the current link for terminology was broken. I have changed the link to point to `documentation overview` where all definitions about Spans, Scopes, Threading, etc. can be found.

I also took the chance to change protocol from http to https in the main project's link.