### PR TITLE
Prepare for 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Master
+## 0.4.2
+
+* Update opentracing.io links and scheme on README ([#38](https://github.com/opentracing/opentracing-ruby/pull/38))
 
 * Add active_span method to Tracer ([#34](https://github.com/opentracing/opentracing-ruby/pull/34))
 

--- a/lib/opentracing/version.rb
+++ b/lib/opentracing/version.rb
@@ -1,3 +1,3 @@
 module OpenTracing
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end


### PR DESCRIPTION
This PR updates the changelog and bumps the version in preparation for 0.4.2 release to address #37. The complete list of changes is below:

* Update opentracing.io links and scheme on README ([#38](https://github.com/opentracing/opentracing-ruby/pull/38))
* Add active_span method to Tracer ([#34](https://github.com/opentracing/opentracing-ruby/pull/34))