### PR TITLE
Version dependencies / Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3
+
+* Specify versions for development dependencies ([#40](https://github.com/opentracing/opentracing-ruby/pull/40))
+
 ## 0.4.2
 
 * Update opentracing.io links and scheme on README ([#38](https://github.com/opentracing/opentracing-ruby/pull/38))

--- a/lib/opentracing/version.rb
+++ b/lib/opentracing/version.rb
@@ -1,3 +1,3 @@
 module OpenTracing
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end

--- a/opentracing.gemspec
+++ b/opentracing.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.54.0'
-  spec.add_development_dependency 'simplecov', '~> 0'
-  spec.add_development_dependency 'simplecov-console', '~> 0'
+  spec.add_development_dependency 'simplecov', '~> 0.16.0'
+  spec.add_development_dependency 'simplecov-console', '~> 0.4.0'
 end


### PR DESCRIPTION
While building the v0.4.2 gem release there were several warnings regarding open ended dependencies. For example:

```
WARNING:  open-ended dependency on simplecov (>= 0, development) is not recommended
  if simplecov is semantically versioned, use:
    add_development_dependency 'simplecov', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

My first attempt to fix this issue was [e588d96](https://github.com/opentracing/opentracing-ruby/commit/e588d96d3d102ac06727339250fa5c3dc6fd5e3b) which was released as 0.4.2. Unfortunately, the bundler versioning broke the [build](https://travis-ci.org/opentracing/opentracing-ruby/builds/444695333. While there isn't technically anything wrong with the ruby code, the officially released gem should have a passing build.

I think it's probably overkill to yank 0.4.2, but I'd like to release this as 0.4.3. Do these changes look ok and does the release plan sound reasonable to everyone?

cc: @indrekj @itsderek23 