### PR TITLE
Fix documentation of Span#log and Span#log_kv methods

### DIFF
--- a/lib/opentracing/span.rb
+++ b/lib/opentracing/span.rb
@@ -46,7 +46,7 @@ module OpenTracing
     # Add a log entry to this span
     # @param event [String] event name for the log
     # @param timestamp [Time] time of the log
-    # @param fields [Hash] Additional information to log
+    # @param fields [Hash{Symbol=>Object}] Additional information to log
     def log(event: nil, timestamp: Time.now, **fields)
       warn 'Span#log is deprecated.  Please use Span#log_kv instead.'
       nil
@@ -54,7 +54,7 @@ module OpenTracing
 
     # Add a log entry to this span
     # @param timestamp [Time] time of the log
-    # @param fields [Hash] Additional information to log
+    # @param fields [Hash{Symbol=>Object}] Additional information to log
     def log_kv(timestamp: Time.now, **fields)
       nil
     end


### PR DESCRIPTION
It was originally accepting kwargs but the documentation says any Hash object would be sufficient. There is no reason to restrict it to only accept hash with symbol keys.

**Current Behaviour:**
It raises `ArgumentError: wrong number of arguments` if you try to give it hash with keys other than symbol.

**Expected/Fixed Behaviour:**
It shouldn't raise exception for hash objects with keys other than symbol.