### PR TITLE
Address issues #13 and #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Tracer#start_span now accepts an optional block. When passed a block, it returns the block's return value, otherwise it returns the newly-created span. See [Issue #13](https://github.com/opentracing/opentracing-ruby/issues/13)
+
+* When passed an optional block, Tracer#start_active_span returns the block's return value, otherwise it returns the newly-created scope. This is a change in behavior as it previously returned a scope in both cases. See [Issue #41](https://github.com/opentracing/opentracing-ruby/issues/41).
+
 ## 0.4.3
 
 * Specify versions for development dependencies ([#40](https://github.com/opentracing/opentracing-ruby/pull/40))

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -77,7 +77,8 @@ module OpenTracing
     # @param ignore_active_scope [Boolean] whether to create an implicit
     #   References#CHILD_OF reference to the ScopeManager#active.
     # @yield [Span] If passed an optional block, start_span will yield the
-    #   newly-created span to the block
+    #   newly-created span to the block. The span will be finished automatically
+    #   after the block is executed.
     # @return [Span, Object] If passed an optional block, start_span will return
     #  the block's return value, otherwise it returns the newly-started Span
     #  instance, which has not been automatically registered via the

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -76,15 +76,21 @@ module OpenTracing
     # @param tags [Hash] Tags to assign to the Span at start time
     # @param ignore_active_scope [Boolean] whether to create an implicit
     #   References#CHILD_OF reference to the ScopeManager#active.
-    # @return [Span] the newly-started Span instance, which has not been
-    #   automatically registered via the ScopeManager
+    # @yield [Span] If passed an optional block, start_span will yield the
+    #   newly-created span to the block
+    # @return [Span, Object] If passed an optional block, start_span will return
+    #  the block's return value, otherwise it returns the newly-started Span
+    #  instance, which has not been automatically registered via the
+    #  ScopeManager
     def start_span(operation_name,
                    child_of: nil,
                    references: nil,
                    start_time: Time.now,
                    tags: nil,
                    ignore_active_scope: false)
-      Span::NOOP_INSTANCE
+      Span::NOOP_INSTANCE.tap do |span|
+        return yield span if block_given?
+      end
     end
 
     # Inject a SpanContext into the given carrier

--- a/lib/opentracing/tracer.rb
+++ b/lib/opentracing/tracer.rb
@@ -42,10 +42,12 @@ module OpenTracing
     #   References#CHILD_OF reference to the ScopeManager#active.
     # @param finish_on_close [Boolean] whether span should automatically be
     #   finished when Scope#close is called
-    # @yield [Scope] If an optional block is passed to start_active it will
+    # @yield [Scope] If an optional block is passed to start_active_span it will
     #   yield the newly-started Scope. If `finish_on_close` is true then the
     #   Span will be finished automatically after the block is executed.
-    # @return [Scope] The newly-started and activated Scope
+    # @return [Scope, Object] If passed an optional block, start_active_span
+    #   returns the block's return value, otherwise it returns the newly-started
+    #   and activated Scope
     def start_active_span(operation_name,
                           child_of: nil,
                           references: nil,
@@ -54,7 +56,7 @@ module OpenTracing
                           ignore_active_scope: false,
                           finish_on_close: true)
       Scope::NOOP_INSTANCE.tap do |scope|
-        yield scope if block_given?
+        return yield scope if block_given?
       end
     end
 

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -25,10 +25,13 @@ class TracerTest < Minitest::Test
   end
 
   def test_start_active_span_accepts_block
-    OpenTracing::Tracer.new.start_active_span('operation_name') do |scope|
+    value = OpenTracing::Tracer.new.start_active_span('operation_name') do |scope|
       assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope
       assert_equal OpenTracing::Span::NOOP_INSTANCE, scope.span
+      true
     end
+
+    assert_equal true, value
   end
 
   def test_inject_text_map

--- a/test/tracer_test.rb
+++ b/test/tracer_test.rb
@@ -11,6 +11,15 @@ class TracerTest < Minitest::Test
                  OpenTracing::Tracer.new.start_span('operation_name', references: references)
   end
 
+  def test_start_span_accepts_block
+    value = OpenTracing::Tracer.new.start_span('operation_name') do |span|
+      assert_equal OpenTracing::Span::NOOP_INSTANCE, span
+      true
+    end
+
+    assert_equal true, value
+  end
+
   def test_start_active_span
     scope = OpenTracing::Tracer.new.start_active_span('operation_name')
     assert_equal OpenTracing::Scope::NOOP_INSTANCE, scope


### PR DESCRIPTION
[#41](https://github.com/opentracing/opentracing-ruby/issues/41) has been open for comment for quite some time, and all feedback has been in favor of the suggested changes. While discussing [#41](https://github.com/opentracing/opentracing-ruby/issues/41) there was interest in addressing [#13](https://github.com/opentracing/opentracing-ruby/issues/13) to provide symmetry between the `Tracer#start_span` and `Tracer#start_active_span` APIs. This PR addresses both [#13](https://github.com/opentracing/opentracing-ruby/issues/13) and [#41](https://github.com/opentracing/opentracing-ruby/issues/41).

`Tracer#start_span` now accepts an optional block. When a block is given, it returns the block's return value, otherwise it returns the newly-created span. See [#13](https://github.com/opentracing/opentracing-ruby/issues/13).

When `Tracer#start_active_span` is given an optional block, it will now return the block's return value, otherwise it returns the newly-created scope. This is a change from the previous behavior where it always returned the newly-created scope. See [#41](https://github.com/opentracing/opentracing-ruby/issues/41).