### PR TITLE
Update changelog and version for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-* Tracer#start_span now accepts an optional block. When passed a block, it returns the block's return value, otherwise it returns the newly-created span. See [Issue #13](https://github.com/opentracing/opentracing-ruby/issues/13)
+## 0.5.0
 
-* When passed an optional block, Tracer#start_active_span returns the block's return value, otherwise it returns the newly-created scope. This is a change in behavior as it previously returned a scope in both cases. See [Issue #41](https://github.com/opentracing/opentracing-ruby/issues/41).
+* Tracer#start_span now accepts an optional block. When passed a block, it returns the block's return value, otherwise it returns the newly-created span ([#45](https://github.com/opentracing/opentracing-ruby/pull/45)). See [Issue #13](https://github.com/opentracing/opentracing-ruby/issues/13).
+
+* When passed an optional block, Tracer#start_active_span returns the block's return value, otherwise it returns the newly-created scope. This is a change in behavior as it previously returned a scope in both cases([#45](https://github.com/opentracing/opentracing-ruby/pull/45)). See [Issue #41](https://github.com/opentracing/opentracing-ruby/issues/41).
+
+* Improved documentation for `log` and `log_kv` methods ([#44](https://github.com/opentracing/opentracing-ruby/pull/44))
 
 ## 0.4.3
 

--- a/lib/opentracing/version.rb
+++ b/lib/opentracing/version.rb
@@ -1,3 +1,3 @@
 module OpenTracing
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
This PR updates the changelog and version for the 0.5.0 release. Below is a summary of the changes:

* Tracer#start_span now accepts an optional block. When passed a block, it returns the block's return value, otherwise it returns the newly-created span ([#45](https://github.com/opentracing/opentracing-ruby/pull/45)). See [Issue #13](https://github.com/opentracing/opentracing-ruby/issues/13).

* When passed an optional block, Tracer#start_active_span returns the block's return value, otherwise it returns the newly-created scope. This is a change in behavior as it previously returned a scope in both cases([#45](https://github.com/opentracing/opentracing-ruby/pull/45)). See [Issue #41](https://github.com/opentracing/opentracing-ruby/issues/41).

* Improved documentation for `log` and `log_kv` methods ([#44](https://github.com/opentracing/opentracing-ruby/pull/44))

Is everyone ok with these changes and the versioning of the next release?